### PR TITLE
Add stickerpacks feature

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -14,6 +14,7 @@ These are divided in different categories depending on the object or concept the
   - [Guild Scheduled Event](#guild-scheduled-event)
   - [Invite](#invite)
   - [Message](#message)
+  - [Sticker](#sticker)
   - [Webhook](#webhook)
 
 ---
@@ -68,6 +69,13 @@ These are divided in different categories depending on the object or concept the
 | Forwarding | Message reference type and field on messages with new message snapshots | Not Released | [GH-6833](https://github.com/discord/discord-api-docs/pull/6833) | [GH-9892](https://github.com/Rapptz/discord.py/pull/9892) | |
 | `POLL_RESULT` Type  | Message type and field on messages with finished polls | Not Released | [GH-7050](https://github.com/discord/discord-api-docs/pull/7050) | [GH-9905](https://github.com/Rapptz/discord.py/pull/9905) | |
 | `PURCHASE_NOTIFICATION` Type | Message type | Not Released | [GH-6927](https://github.com/discord/discord-api-docs/pull/6927) | [GH-9906](https://github.com/Rapptz/discord.py/pull/9906) | |
+
+
+### Sticker
+
+|    Feature    |    Description    |    Status    |    Discord Docs PR    |    discord.py PR    |    Notes    |
+|---------------|-------------------|--------------|-----------------------|---------------------|-------------|
+| Sticker Packs | Adds support for getting sticker packs | Not Released | [GH-7065](https://github.com/discord/discord-api-docs/pull/7065) | [GH-9893](https://github.com/Rapptz/discord.py/pull/9909) | |
 
 ### Webhook
 


### PR DESCRIPTION
## Brief Description

Adds the sticker packs feature.

## Detailed Description

Saw the following PR on the discord-api-docs repo: https://github.com/discord/discord-api-docs/pull/7065

## Change Log

<!-- List the changes you made, does not have to be in any particular order -->
- Added a Sticker header and Content index
- Added the described feature

## Checklist

<!-- Check the boxes with [x] for those items that your PR meets -->

- [x] PR contents come from a trusted source, such as DDevs Docs PR, [unofficial documentation](https://docs.discord.sex/), Discord staff mention, or others.
- [x] Changed files formatting works as expected.
- [ ] This is **not** a features code change.